### PR TITLE
PostGIS container would not build

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -16,17 +16,18 @@ RUN apt-get update \
     proj-bin \
     proj-data \
     # - JSON
-    libjson0 \
-    libjson0-dev \
+    libjson-c3 \
+    libjson-c-dev \
     python-simplejson \
     # - GEOS
-    libgeos-c1 \
+    libgeos-c1v5 \
     libgeos-dev \
     # - GDAL
+    libgdal20 \
     gdal-bin \
-    libgdal1-dev \
+    libgdal-dev \
     # PostGIS
-    liblwgeom-2.1.4 \
+    liblwgeom-2.3\* \
     libxml2-dev \
     postgis-2.3 \
     postgresql-9.5-postgis-2.3 \


### PR DESCRIPTION
I attempted a `docker-compose up` of the entire repo, and had a failed `docker build` on the PostGIS service image.

Not sure this is the best/intended fix, but it did result in a clean build.  
I opted to go with liblwgeom-2.3 (2.4 is available in the upstream repositories)

Thought this might help.  Post-fix of the Dockerfile, I had a successful build of all the containers.

Nice work on the repo @davschne 